### PR TITLE
Integate tests as actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,26 @@
+name: Tests
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        python-version: ['3.6', '3.7', '3.8', '3.9']
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install tox tox-gh-actions
+    - name: Test with tox
+      run: tox

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest]
         python-version: ['3.6', '3.7', '3.8', '3.9']
 
     steps:
@@ -21,5 +21,6 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        pip install tox tox-gh-actions
     - name: Test with pytest
-      run: pytest
+      run: tox

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,6 +21,5 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install tox tox-gh-actions
-    - name: Test with tox
-      run: tox
+    - name: Test with pytest
+      run: pytest

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![PyPI Version](https://img.shields.io/pypi/v/defichain.svg?color=green)](https://pypi.org/project/defichain)
 [![PyPI Python Version](https://img.shields.io/pypi/pyversions/defichain.svg)](https://pypi.org/project/defichain)
 [![Documentation Status](https://readthedocs.org/projects/pytest/badge/?version=latest)](https://docs.defichain-python.de/)
+![Tests](https://github.com/mCodingLLC/DefichainPython/actions/workflows/tests.yml/badge.svg)
 [![Downloads](https://static.pepy.tech/personalized-badge/defichain?period=total&units=international_system&left_color=grey&right_color=green&left_text=Downloads)](https://pepy.tech/project/defichain)
 
 # [DefichainPython](https://github.com/eric-volz/DefichainPython)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,8 @@
+[build-system]
+requires = ["setuptools>=42.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.pytest.ini_options]
+testpaths = [
+    "tests/hdwallet", "tests/ocean"
+]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,10 @@
+[pytest]
+markers =
+    mandatory: object or methods that are mandatory for the library
+    query: methods that are just querying data from the node
+    transactions: methods that are sending a transaction
+    hdwallet: classes and methods that are corresponding to hdwallet
+
+testpaths =
+    tests/hdwallet
+    tests/ocean

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,11 +1,4 @@
-sphinx~=4.5.0
-sphinx_rtd_theme~=1.0.0
-pytest~=7.1.1
+pytest~=7.0.1
 pytest-cov==4.0.0
 tox==3.26.0
-requests~=2.27.1
 setuptools~=57.0.0
-furo~=2022.4.7
-sphinx_mdinclude~=0.5.1
-sphinx_inline_tabs~=2022.1.2b11
-sphinxemoji~=0.2.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,6 +1,8 @@
 sphinx~=4.5.0
 sphinx_rtd_theme~=1.0.0
 pytest~=7.1.1
+pytest-cov==4.0.0
+tox==3.26.0
 requests~=2.27.1
 setuptools~=57.0.0
 furo~=2022.4.7

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -1,0 +1,6 @@
+sphinx~=4.5.0
+sphinx_rtd_theme~=1.0.0
+furo~=2022.4.7
+sphinx_mdinclude~=0.5.1
+sphinx_inline_tabs~=2022.1.2b11
+sphinxemoji~=0.2.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,19 @@
+[tox]
+minversion = 3.8.0
+envlist = py3.6, py3.7, py3.8, py3.9
+isolated_build = true
+
+[gh-actions]
+python =
+    3.6: py3.6
+    3.7: py3.7
+    3.8: py3.8
+    3.9: py3.9
+
+[testenv]
+setenv =
+    PYTHONPATH = {toxinidir}
+deps =
+    -r{toxinidir}/requirements_dev.txt
+commands =
+    pytest --basetemp={envtmpdir}


### PR DESCRIPTION
With every push the tests of ocean and hdwallet will run.
Tests for node will follow: Requires a defichain node in the background