### PR TITLE
Implement signing of P2PKH address type

### DIFF
--- a/defichain/transactions/builder/rawtransactionbuilder.py
+++ b/defichain/transactions/builder/rawtransactionbuilder.py
@@ -5,8 +5,8 @@ from defichain.transactions.address import Address
 from defichain.transactions.constants import AddressTypes, DefiTxType
 from defichain.networks import Network
 from defichain.transactions.remotedata.remotedata import RemoteData
-from defichain.transactions.rawtransactions import Transaction, TxInput, TxP2WPKHInput, TxP2SHInput, TxAddressOutput, \
-    TxDefiOutput, estimate_fee
+from defichain.transactions.rawtransactions import Transaction, TxInput, TxP2PKHInput, TxP2WPKHInput, TxP2SHInput, \
+    TxAddressOutput, TxDefiOutput, estimate_fee
 from defichain.transactions.defitx.modules.basedefitx import BaseDefiTx
 
 
@@ -34,7 +34,7 @@ class RawTransactionBuilder:
                 address = Address.from_scriptPublicKey(self.get_account().get_network(), input["scriptPubKey"])
                 # Build P2PKH Input
                 if address.get_addressType() == AddressTypes.P2PKH:
-                    raise NotYetSupportedError()
+                    tx.add_input(TxP2PKHInput(input["txid"], input["vout"], self.get_address(), input["value"]))
                 # Build P2SH Input
                 elif address.get_addressType() == AddressTypes.P2SH:
                     tx.add_input(TxP2SHInput(input["txid"], input["vout"], self.get_account().get_p2wpkh(),
@@ -44,7 +44,7 @@ class RawTransactionBuilder:
                     tx.add_input(TxP2WPKHInput(input["txid"], input["vout"], self.get_address(), input["value"]))
             # Check Inputs for masternode collateral
             tx.set_inputs(self.checkMasternodeInputs(tx.get_inputs()))
-        if tx.get_inputs() == []:
+        if not tx.get_inputs():
             raise TxBuilderError(f"Given address: {self._address} has no unspent inputs. Check your builder object!")
         return tx
 

--- a/defichain/transactions/rawtransactions/tx.py
+++ b/defichain/transactions/rawtransactions/tx.py
@@ -131,8 +131,7 @@ class BaseTransaction(TxBase, ABC):
         return Converter.bytes_to_hex(bytes(reversed(Calculate.dHash256(self.bytes_unsigned()))))
 
     def get_hash(self):
-        hash = Calculate.dHash256(self.bytes())
-        return Converter.bytes_to_hex(bytes(reversed(hash)))
+        return Converter.bytes_to_hex(bytes(reversed(Calculate.dHash256(self.bytes()))))
 
     def get_bytes_version(self) -> bytes:
         return Converter.int_to_bytes(self.get_version(), 4)

--- a/defichain/transactions/rawtransactions/txinput.py
+++ b/defichain/transactions/rawtransactions/txinput.py
@@ -95,7 +95,9 @@ class TxBaseInput(TxBase, ABC):
         return Converter.int_to_bytes(self.get_value(), 8)
 
     def get_bytes_unsignedInput(self) -> bytes:
-        return self.get_bytes_txid() + self.get_bytes_vout() + Converter.int_to_bytes(0, 1) + self.get_bytes_sequence()
+        scriptSigLength = len(self.get_bytes_scriptSig())
+        return self.get_bytes_txid() + self.get_bytes_vout() + Converter.int_to_bytes(scriptSigLength, 1) + \
+            self.get_bytes_scriptSig() + self.get_bytes_sequence()
 
     # Set Information
     def set_txid(self, txid: str) -> None:


### PR DESCRIPTION
Before this update it was only possible to create transactions for P2SH and P2WPKH addresses.
Now it is also possible to create and sign transactions for P2PKH addresses.

**Address Types Examples:** 
P2PKH: 8KWs4zfdiZt5ywdfxiZBNVqpN33Q6uADnE
P2SH: dYYDGkxDwZryP1K8Ks9NNQKGVQrWjpivF5
P2WPKH: df1q9zn73ca4mt39qe76mkxa4vf4caqsxuhk8d9wgw